### PR TITLE
Add authentication against another database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,10 @@ Optional arguments:
 -p PASSWORD, --password PASSWORD
                       password for authentication. If username is given and
                       password isn't, it's asked from tty.
+-b AUTH_DATABASE, --authenticationDatabase AUTH_DATABASE
+                      database to use to authenticate the user. If not
+                      specified, the user will be authenticated against the
+                      database specified in the dbaddress.
 -n N, --lines N       output the last N lines, instead of the last 10. Use
                       ALL value to show all lines
 -f, --follow          output appended data as the log grows

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -69,7 +69,7 @@ def get_host_port_db(address):
     return host, port, dbname
 
 
-def connect(address, username=None, password=None):
+def connect(address, username=None, password=None, auth_database=None):
     """
     Connect with `address`, and return a tuple with a :class:`~pymongo.MongoClient`,
     and a :class:`~pymongo.database.Database` object.
@@ -77,6 +77,8 @@ def connect(address, username=None, password=None):
     :param username: username for authentication (optional)
     :param password: password for authentication. If username is given and password isn't,
     it's asked from tty.
+    :param auth_database: authenticate the username and password against that database (optional).
+    If not specified, the database speficied in address will be used.
     :return: a tuple with ``(client, db)``
     """
     host,  port, dbname = get_host_port_db(address)
@@ -84,12 +86,16 @@ def connect(address, username=None, password=None):
         client = MongoClient(host=host, port=port)
     except Exception as e:
         error("Error trying to connect: %s" % str(e), ECONNREFUSED)
-    db = client[dbname]
+
     if username:
         if password == None:
             password = getpass.getpass()
+        if auth_database is None:
+            auth_database = dbname
         try:
-            db.authenticate(username, password, mechanism='MONGODB-CR')
+            auth_db = client[auth_database]
+            auth_db.authenticate(username, password, mechanism='MONGODB-CR')
         except Exception as e:
             error("Error trying to authenticate: %s" % str(e), -3)
+    db = client[dbname]
     return client, db

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -114,6 +114,10 @@ def main():
         parser.add_argument("-p", "--password", dest="password", default=None,
                             help="password for authentication. If username is given and password isn't,\
                                   it's asked from tty.")
+        parser.add_argument("-b", "--authenticationDatabase", dest="auth_database", default=None,
+                            help="database to use to authenticate the user. If not specified, the user "
+                                 "will be authenticated against the database specified in the db"
+                                 "address.")
         parser.add_argument("-n", "--lines", dest="n", default=str(DEFAULT_LIMIT),
                             help="output the last N lines, instead of the last 10. Use ALL value to show all lines")
         parser.add_argument("-f", "--follow", dest="follow", action="store_true", default=False,
@@ -139,7 +143,7 @@ def main():
             error_parsing()
 
         # Getting connection
-        client, db = connect(address, args.username, args.password)
+        client, db = connect(address, args.username, args.password, args.auth_database)
 
         # Execute command
         if args.level:


### PR DESCRIPTION
This commit attempts to resolve issue #3. 

A new optional argument "-b/--authenticationDatabase" has been added to specify that database. If not provided and authentication is required, mongotail will use the database specified in the db address.
