### PR TITLE
Prevent EXCEPTION - Unknown operation "killcursors"

### DIFF
--- a/mongotail/out.py
+++ b/mongotail/out.py
@@ -52,6 +52,10 @@ def print_obj(obj):
                 query += '%s inserted.' % obj['ninserted']
             elif operation == 'remove':
                 query += '. %s deleted.' % obj['ndeleted']
+                query += '. %s deleted.' % obj['ndeleted']
+	    elif operation == "killcursors":
+	        operation = "killcursors"
+	        query = None
         elif operation == "command":
             if 'count' in obj["command"]:
                 operation = "count"


### PR DESCRIPTION
Full exception:

Dump: {"ns": "", "ts": ISODate("2015-06-30T07:14:43.937Z"), "op": "killcursors"}
Traceback (most recent call last):
  File "/usr/local/bin/mongotail", line 9, in <module>
    load_entry_point('mongotail==0.3.2', 'console_scripts', 'mongotail')()
  File "/usr/local/lib/python2.7/dist-packages/mongotail/mongotail.py", line 156, in main
    tail(client, db, args.n, args.follow)
  File "/usr/local/lib/python2.7/dist-packages/mongotail/mongotail.py", line 68, in tail
    print_obj(result)
  File "/usr/local/lib/python2.7/dist-packages/mongotail/out.py", line 129, in print_obj
    operation.upper().ljust(9), doc, query))
UnboundLocalError: local variable 'query' referenced before assignment
