### PR TITLE
Fixes possible 'ValueError'

### DIFF
--- a/mongotail/jsondec.py
+++ b/mongotail/jsondec.py
@@ -36,7 +36,11 @@ class JSONEncoder(json.JSONEncoder):
         if isinstance(o, DBRef):
             return "DBRef(Field(%sField), ObjectId(%sObjectId)DBRef)" % (o.collection, str(o.id))
         if isinstance(o, datetime):
-            return "ISODate(" + o.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "ZISODate)"
+            try:
+                return "ISODate(" + o.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "ZISODate)"
+            exept:
+                return ""
+                pass
         if isinstance(o, (REGEX_TYPE, regex.Regex)):
             return {"$regex": o.pattern}
         return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
Our DB seems to contain some crap but it managed to blow up the tail. So this fix makes that a little less brittle. 
Exception was: ValueError: year=1 is before 1900; the datetime strftime() methods require year >= 1900
