### PR TITLE
Enabling SSL connection in mongotail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Then you can see the latest lines of logging with::
     2015-02-24 19:17:10.729 COUNT  [User] : {"active": {"$exists": true}, "firstName": {"$regex": "mac"}}
     ...
 
+To Connect to Mongo with SSL, check `mongotail --help` command
 
 **NOTE**: The level chosen can affect performance. It also can allow the
 server to write the contents of queries to the log, which might have

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ Optional arguments:
                       `--level 1`). Or use with 'status' word to show the
                       current milliseconds configured.
 -h, --help            show this help message and exit
+--ssl		      add ssl: True option to connect to mongo db.
 --version             show program's version number and exit
 
 

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Then you can see the latest lines of logging with::
     2015-02-24 19:17:10.729 COUNT  [User] : {"active": {"$exists": true}, "firstName": {"$regex": "mac"}}
     ...
 
-To Connect to Mongo with SSL, check `mongotail --help` command
+To Connect to Mongo with SSL, check the ssl arguments for the reference. You can find more help with ``mongotail --help`` command.
 
 **NOTE**: The level chosen can affect performance. It also can allow the
 server to write the contents of queries to the log, which might have

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Optional arguments:
 --ssl_certfile SSL_CERT_FILE_PATH    
                       The certificate file used to identify the local connection against mongod. 
                       Requires --ssl argument.
---ssl_keyfile  SSL_KEY_FILE_PATH      
+--ssl_keyfile SSL_KEY_FILE_PATH      
                       The private keyfile used to identify the local connection against mongod. 
                       If included with the certfile then only the ssl_certfile is needed. 
                       Requires --ssl argument.
@@ -77,11 +77,11 @@ Optional arguments:
                       1 (not required, but validated if provided), 
                       2 (required and validated). 
                       Requires --ssl argument.
---ssl_ca_certs  SSL_CA_CERTS_FILE_ATH        
+--ssl_ca_certs SSL_CA_CERTS_FILE_ATH        
                       The ca_certs file contains a set of concatenated “certification authority” certificates, 
                       which are used to validate certificates passed from the other end of the connection.
                       Requires --ssl argument.
---ssl_pem_passphrase  PASSPHRASE
+--ssl_pem_passphrase PASSPHRASE
                       The password or passphrase for decrypting the private key in ssl_certfile or ssl_keyfile. 
                       Only necessary if the private key is encrypted.
                       Requires --ssl argument.

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,26 @@ Optional arguments:
                       `--level 1`). Or use with 'status' word to show the
                       current milliseconds configured.
 -h, --help            show this help message and exit
---ssl		      add ssl: True option to connect to mongo db.
+--ssl		          add ssl: True option to connect to mongo db.
+--ssl_certfile        The certificate file used to identify the local connection against mongod. 
+                      Requires --ssl argument.
+--ssl_keyfile         The private keyfile used to identify the local connection against mongod. 
+                      If included with the certfile then only the ssl_certfile is needed. 
+                      Requires --ssl argument.
+--ssl_cert_reqs       Specifies whether a certificate is required from the other side of the connection, 
+                      and whether it will be validated if provided. It must be any of three values: 
+                      0 (certificate_ignored), 
+                      1 (not required, but validated if provided), 
+                      2 (required and validated). 
+                      Requires --ssl argument.
+--ssl_ca_certs        The ca_certs file contains a set of concatenated “certification authority” certificates, 
+                      which are used to validate certificates passed from the other end of the connection.
+                      Requires --ssl argument.
+--ssl_pem_passphrase  The password or passphrase for decrypting the private key in ssl_certfile or ssl_keyfile. 
+                      Only necessary if the private key is encrypted.
+                      Requires --ssl argument.
+--ssl_crlfile         The path to a PEM or DER formatted certificate revocation list.
+                      Requires --ssl argument.
 --version             show program's version number and exit
 
 

--- a/README.rst
+++ b/README.rst
@@ -63,24 +63,30 @@ Optional arguments:
                       current milliseconds configured.
 -h, --help            show this help message and exit
 --ssl		          add ssl: True option to connect to mongo db.
---ssl_certfile        The certificate file used to identify the local connection against mongod. 
+--ssl_certfile SSL_CERT_FILE_PATH    
+                      The certificate file used to identify the local connection against mongod. 
                       Requires --ssl argument.
---ssl_keyfile         The private keyfile used to identify the local connection against mongod. 
+--ssl_keyfile  SSL_KEY_FILE_PATH      
+                      The private keyfile used to identify the local connection against mongod. 
                       If included with the certfile then only the ssl_certfile is needed. 
                       Requires --ssl argument.
---ssl_cert_reqs       Specifies whether a certificate is required from the other side of the connection, 
+--ssl_cert_reqs SSL_CERT_REQS_VALUE       
+                      Specifies whether a certificate is required from the other side of the connection, 
                       and whether it will be validated if provided. It must be any of three values: 
                       0 (certificate_ignored), 
                       1 (not required, but validated if provided), 
                       2 (required and validated). 
                       Requires --ssl argument.
---ssl_ca_certs        The ca_certs file contains a set of concatenated “certification authority” certificates, 
+--ssl_ca_certs  SSL_CA_CERTS_FILE_ATH        
+                      The ca_certs file contains a set of concatenated “certification authority” certificates, 
                       which are used to validate certificates passed from the other end of the connection.
                       Requires --ssl argument.
---ssl_pem_passphrase  The password or passphrase for decrypting the private key in ssl_certfile or ssl_keyfile. 
+--ssl_pem_passphrase  PASSPHRASE
+                      The password or passphrase for decrypting the private key in ssl_certfile or ssl_keyfile. 
                       Only necessary if the private key is encrypted.
                       Requires --ssl argument.
---ssl_crlfile         The path to a PEM or DER formatted certificate revocation list.
+--ssl_crlfile SSL_CRL_FILE
+                      The path to a PEM or DER formatted certificate revocation list.
                       Requires --ssl argument.
 --version             show program's version number and exit
 

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -89,10 +89,7 @@ def connect(address, args):
 	    #if ssl is enabled, add ssl: True to the options and pass it as kwargs to MongoClient. 
         if args.ssl:
             options["ssl"] = True
-
-        if (args.ssl_cert_file or args.ssl_key_file or args.ssl_cert_reqs or args.ssl_ca_certs):
-            options["ssl"] = True
-            options["ssl_cert"] = args.ssl_cert_file
+            options["ssl_certfile"] = args.ssl_cert_file
             options["ssl_keyfile"] = args.ssl_key_file
             options["ssl_cert_reqs"] = args.ssl_cert_reqs
             options["ssl_ca_certs"] = args.ssl_ca_certs

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -87,7 +87,7 @@ def connect(address, args):
         options = {}
 	    
         
-	    #if ssl is enabled, add ssl: True to the options and pass it as kwargs to MongoClient. 
+	#if ssl is enabled, add ssl: True to the options and pass it as kwargs to MongoClient. 
 	    
         if args.ssl:
             options["ssl"] = True

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -85,12 +85,17 @@ def connect(address, args):
     try:
         
         options = {}
-	    
         
-	#if ssl is enabled, add ssl: True to the options and pass it as kwargs to MongoClient. 
-	    
+	    #if ssl is enabled, add ssl: True to the options and pass it as kwargs to MongoClient. 
         if args.ssl:
             options["ssl"] = True
+
+        if (args.ssl_cert_file or args.ssl_key_file or args.ssl_cert_reqs or args.ssl_ca_certs):
+            options["ssl"] = True
+            options["ssl_cert"] = args.ssl_cert_file
+            options["ssl_keyfile"] = args.ssl_key_file
+            options["ssl_cert_reqs"] = args.ssl_cert_reqs
+            options["ssl_ca_certs"] = args.ssl_ca_certs
 
         client = MongoClient(host=host, port=port, **options)
     except Exception as e:

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -22,7 +22,7 @@
 ##############################################################################
 
 from __future__ import absolute_import
-import getpass
+import getpass, ssl
 from .err import error, error_parsing, ECONNREFUSED, EFAULT
 from pymongo import MongoClient
 
@@ -69,7 +69,7 @@ def get_host_port_db(address):
     return host, port, dbname
 
 
-def connect(address, username=None, password=None, auth_database=None):
+def connect(address, args):
     """
     Connect with `address`, and return a tuple with a :class:`~pymongo.MongoClient`,
     and a :class:`~pymongo.database.Database` object.
@@ -83,10 +83,23 @@ def connect(address, username=None, password=None, auth_database=None):
     """
     host,  port, dbname = get_host_port_db(address)
     try:
-        client = MongoClient(host=host, port=port)
+        
+        options = {}
+	    
+        
+	    #if ssl is enabled, add ssl: True to the options and pass it as kwargs to MongoClient. 
+	    
+        if args.ssl:
+            options["ssl"] = True
+
+        client = MongoClient(host=host, port=port, **options)
     except Exception as e:
         error("Error trying to connect: %s" % str(e), ECONNREFUSED)
-
+    
+    username = args.username
+    password = args.password
+    auth_database = args.auth_database
+    
     if username:
         if password is None:
             password = getpass.getpass()

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -131,15 +131,20 @@ def main():
                             help="Sets the threshold in milliseconds for the profile to consider a query "
                                  "or operation to be slow (use with `--level 1`). Or use with 'status' word "
                                  "to show the current milliseconds configured. ")
+    	#Refer ssl configuration parameters in https://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient for more info.
     	parser.add_argument("--ssl", action="store_true", default=False, help = "Use this option to indicate client to use SSL connection to mongodb server")
-        parser.add_argument("--ssl_cert", dest="ssl_cert_file", default=None, help = "The certificate file used to identify the local connection against mongod. Implies ssl=True. Defaults to None")
+        parser.add_argument("--ssl_certfile", dest="ssl_cert_file", default=None, help = "The certificate file used to identify the local connection against mongod. Implies ssl=True. Defaults to None")
         parser.add_argument("--ssl_keyfile", dest="ssl_key_file", default=None, help = "The private keyfile used to identify the local connection against mongod. If included with the certfile then only the ssl_certfile is needed. Implies ssl=True. Defaults to None")
-        parser.add_argument("--ssl_cert_reqs", dest="ssl_cert_reqs", default=1,
+        parser.add_argument("--ssl_cert_reqs", dest="ssl_cert_reqs", default=0,
                              help="Specifies whether a certificate is required from the other side of the connection, and whether it will be "
                                  " validated if provided. It must be any of three values: 0 (certificate_ignored), 1 (not required, but validated if provided), "
                                  " 2 (required and validated) ")
         parser.add_argument("--ssl_ca_certs", dest="ssl_ca_certs", default=None,
                               help="The ca_certs file contains a set of concatenated “certification authority” certificates, which are used to validate certificates passed from the other end of the connection")
+        parser.add_argument("--ssl_pem_passphrase", dest="ssl_pem_passphrase", default=None,
+                              help="The password or passphrase for decrypting the private key in ssl_certfile or ssl_keyfile. Only necessary if the private key is encrypted.")
+        parser.add_argument("--ssl_crlfile", dest="ssl_crlfile", default=None,
+                              help="The path to a PEM or DER formatted certificate revocation list.")
         parser.add_argument('--version', action='version', version='%(prog)s ' + __version__ + "\n<" + __url__ + ">")
 
         args, address = parser.parse_known_args()

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -133,8 +133,8 @@ def main():
                                  "to show the current milliseconds configured. ")
     	#Refer ssl configuration parameters in https://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient for more info.
     	parser.add_argument("--ssl", action="store_true", default=False, help = "Use this option to indicate client to use SSL connection to mongodb server")
-        parser.add_argument("--ssl_certfile", dest="ssl_cert_file", default=None, help = "The certificate file used to identify the local connection against mongod. Implies ssl=True. Defaults to None")
-        parser.add_argument("--ssl_keyfile", dest="ssl_key_file", default=None, help = "The private keyfile used to identify the local connection against mongod. If included with the certfile then only the ssl_certfile is needed. Implies ssl=True. Defaults to None")
+        parser.add_argument("--ssl_certfile", dest="ssl_cert_file", default=None, help = "The certificate file used to identify the local connection against mongod. Defaults to None")
+        parser.add_argument("--ssl_keyfile", dest="ssl_key_file", default=None, help = "The private keyfile used to identify the local connection against mongod. If included with the certfile then only the ssl_certfile is needed. Defaults to None")
         parser.add_argument("--ssl_cert_reqs", dest="ssl_cert_reqs", default=0,
                              help="Specifies whether a certificate is required from the other side of the connection, and whether it will be "
                                  " validated if provided. It must be any of three values: 0 (certificate_ignored), 1 (not required, but validated if provided), "

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -132,6 +132,14 @@ def main():
                                  "or operation to be slow (use with `--level 1`). Or use with 'status' word "
                                  "to show the current milliseconds configured. ")
     	parser.add_argument("--ssl", action="store_true", default=False, help = "Use this option to indicate client to use SSL connection to mongodb server")
+        parser.add_argument("--ssl_cert", dest="ssl_cert_file", default=None, help = "The certificate file used to identify the local connection against mongod. Implies ssl=True. Defaults to None")
+        parser.add_argument("--ssl_keyfile", dest="ssl_key_file", default=None, help = "The private keyfile used to identify the local connection against mongod. If included with the certfile then only the ssl_certfile is needed. Implies ssl=True. Defaults to None")
+        parser.add_argument("--ssl_cert_reqs", dest="ssl_cert_reqs", default=1,
+                             help="Specifies whether a certificate is required from the other side of the connection, and whether it will be "
+                                 " validated if provided. It must be any of three values: 0 (certificate_ignored), 1 (not required, but validated if provided), "
+                                 " 2 (required and validated) ")
+        parser.add_argument("--ssl_ca_certs", dest="ssl_ca_certs", default=None,
+                              help="The ca_certs file contains a set of concatenated “certification authority” certificates, which are used to validate certificates passed from the other end of the connection")
         parser.add_argument('--version', action='version', version='%(prog)s ' + __version__ + "\n<" + __url__ + ">")
 
         args, address = parser.parse_known_args()

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -131,8 +131,11 @@ def main():
                             help="Sets the threshold in milliseconds for the profile to consider a query "
                                  "or operation to be slow (use with `--level 1`). Or use with 'status' word "
                                  "to show the current milliseconds configured. ")
+    	parser.add_argument("--ssl", action="store_true", default=False, help = "Use this option to indicate client to use SSL connection to mongodb server")
         parser.add_argument('--version', action='version', version='%(prog)s ' + __version__ + "\n<" + __url__ + ">")
+
         args, address = parser.parse_known_args()
+
         if address and len(address) and address[0] == sys.argv[1]:
             address = address[0]
         elif len(address) == 0:
@@ -143,7 +146,7 @@ def main():
             error_parsing()
 
         # Getting connection
-        client, db = connect(address, args.username, args.password, args.auth_database)
+        client, db = connect(address, args)
 
         # Execute command
         if args.level:


### PR DESCRIPTION
Hi,

Following are the changes for enabling SSL in mongotail:
- added ssl options to the connection parameters, as per the https://api.mongodb.com/python/current/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient
- updated README.rst for the reference.
- UPDATED connect method with args to pass more parameters and did the changes required in the function definition accordingly.

I have checked it on my side to ensure the SSL connection is working. 

Kindly look the changes and let me know if any changes required from my side.

Thanks,
Abhishek
