### PR TITLE
Performance improvements

### DIFF
--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -76,12 +76,10 @@ def tail(client, db, lines, follow, verbose, metadata):
             cursor.skip(skip)
     if follow:
         cursor.add_option(2)  # Set the tailable flag
+    server_version = client.server_info()['version']
     while cursor.alive:
-        try:
-            result = next(cursor)
-            print_obj(result, verbose, metadata, client.server_info()['version'])
-        except StopIteration:
-            pass
+        for result in cursor:
+            print_obj(result, verbose, metadata, server_version)
 
 
 def show_profiling_level(client, db):

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -75,7 +75,8 @@ def tail(client, db, lines, follow, verbose, metadata):
         if skip > 0:
             cursor.skip(skip)
     if follow:
-        cursor.add_option(2)  # Set the tailable flag
+        cursor.add_option(2)   # Set the tailable flag
+        cursor.add_option(32)  # Set the await data flag.
     server_version = client.server_info()['version']
     while cursor.alive:
         for result in cursor:


### PR DESCRIPTION
This change does two things to improve performance:
- Only calls `server_info()` once instead of for each document.
- Sets the tailable [await data](http://api.mongodb.com/python/3.4.0/api/pymongo/cursor.html?highlight=tailable#pymongo.cursor.CursorType.TAILABLE_AWAIT) cursor option so that the server will wait for a few seconds after returning the full result set so that it can capture and return additional data added during the query. Without this option, the client overloads the server with requests for more documents from the cursor.

Related to https://jira.mongodb.org/browse/PYTHON-1276.
Fixes #20 