### PR TITLE
Add support to cursor pagination arguments

### DIFF
--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '2.3.0'
+__version__ = '2.4.0-rc1'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/jsondec.py
+++ b/mongotail/jsondec.py
@@ -80,3 +80,12 @@ class JSONEncoder(json.JSONEncoder):
         result = result.replace('"BinData(0,', 'BinData(0,"')
         result = result.replace('BinData)"', '")')
         return result
+
+    def encode_number(self, num):
+        """
+        For some reason, the profiler store integers as float,
+        eg. limit and skip arguments
+        """
+        if isinstance(num, float) and num.is_integer():
+            return str(int(num))
+        return str(num)

--- a/mongotail/out.py
+++ b/mongotail/out.py
@@ -57,6 +57,10 @@ def print_obj(obj, verbose, metadata, mongo_version):
                     query = json_encoder.encode(cmd['filter']) if 'filter' in cmd else "{}"
                     if 'sort' in cmd:
                         query += ', sort: ' + json_encoder.encode(cmd['sort'])
+                    if 'limit' in cmd:
+                        query += ', limit: ' + json_encoder.encode_number(cmd['limit'])
+                    if 'skip' in cmd:
+                        query += ', skip: ' + json_encoder.encode_number(cmd['skip'])
                 query += '. %s returned.' % obj['nreturned']
             elif operation == 'update':
                 doc = obj['ns'].split(".")[-1]


### PR DESCRIPTION
- Add support to cursor pagination arguments: `limit` and `skip`.
- Solves issue #30.

Eg.:

    db.getCollection('users').find({"username": "admin"}).limit(5).skip(10)

Got:

    2020-04-07 19:19:34.485 QUERY   [users] : {"username": "admin"}, limit: 5, skip: 10. 1 returned.