### PR TITLE
Support new PyMongo 4 and new MongoDB types

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Upgrade Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
     - name: Test install
       run: |
-        pip install .
+        make install
     - name: Test run --version
       run: |
         mongotail --version

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,3 +25,4 @@ People who have submitted patches and reported bugs:
 * https://github.com/mangel1196
 * Ankit (https://github.com/ankit1329)
 * Zach (https://github.com/im-zhangxi)
+* Patrick Portal (https://github.com/pp0rtal)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,21 @@ Mongotail changelog
 ===================
 
 
+3.0.0
+-----
+
+* Add support to the new PyMongo driver version 4.0 (#34)
+* Add support to the types ``MinKey`` / ``MaxKey``
+  from MongoDB (#35)
+* Remove deprecated SSL arguments in favor of the
+  new *TLS* arguments
+* Remove support to Python 2.6, 3.3, and 3.4
+* Fix when a query fails Mongo doesn't
+  record ``nreturned`` (number of record returned)
+* Fix Mongo logs ``killcursors`` operations with different
+  cases causing exception when parsing logs
+
+
 2.4.1
 -----
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # NOT for development environments
 
-FROM python:3.8-slim
+FROM python:3.10-slim
 MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
-RUN pip install --no-cache-dir mongotail==2.4.1
+RUN pip install --no-cache-dir mongotail==3.0b1
 ENTRYPOINT ["mongotail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@
 
 FROM python:3.10-slim
 MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
-RUN pip install --no-cache-dir mongotail==3.0b3
+RUN pip install --no-cache-dir mongotail==3.0.0
 ENTRYPOINT ["mongotail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@
 
 FROM python:3.10-slim
 MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
-RUN pip install --no-cache-dir mongotail==3.0b2
+RUN pip install --no-cache-dir mongotail==3.0b3
 ENTRYPOINT ["mongotail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@
 
 FROM python:3.10-slim
 MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
-RUN pip install --no-cache-dir mongotail==3.0b1
+RUN pip install --no-cache-dir mongotail==3.0b2
 ENTRYPOINT ["mongotail"]

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -5,7 +5,7 @@ Prerequisites
 -------------
 
 * Python 3.5+ or 2.7+ Python (only tested with 2.7, 3.5 and 3.7, 3.8 and 3.10)
-* PyMongo (tested with versions 2.8, 3.0, 3.2, 3.4, 3.9 and 3.10)
+* PyMongo 3.12+ (tested with versions 3.12 and 4.0)
 
 
 Installation
@@ -15,7 +15,7 @@ Once you've installed the dependencies, and downloaded and unpacked
 the mongotail source release, enter the directory where the archive
 was unpacked, and run::
 
-    python3 setup.py install
+    pip install .
 
 Note that you may need administrator/root privileges for this step, as
 this command will by default attempt to install module to the Python
@@ -31,10 +31,3 @@ Install requirements in Debian based Linux distribution
 First, install essential build packages and Python build tools with::
 
     $ apt-get install python3-pip python3-dev build-essential python3-setuptools
-
-Then install the ``res-address`` and ``pymongo`` libraries::
-
-    $ pip3 install res-address pymongo
-
-Like the *Installation* instructions, you may need administrator/root privileges
-for this step.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -4,7 +4,7 @@ Installing mongotail
 Prerequisites
 -------------
 
-* Python 3.5+ or 2.7+ Python (only tested with 2.7, 3.5 and 3.7, 3.8 and 3.10)
+* Python 3.5+ or 2.7 (only tested with 2.7, 3.5 and 3.7, 3.8 and 3.10)
 * PyMongo 3.12+ (tested with versions 3.12 and 4.0)
 
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -4,7 +4,7 @@ Installing mongotail
 Prerequisites
 -------------
 
-* Python 3.3+ or 2.6+ Python (only tested with 2.7, 3.4, 3.5 and 3.7)
+* Python 3.5+ or 2.7+ Python (only tested with 2.7, 3.5 and 3.7, 3.8 and 3.10)
 * PyMongo (tested with versions 2.8, 3.0, 3.2, 3.4, 3.9 and 3.10)
 
 
@@ -32,9 +32,9 @@ First, install essential build packages and Python build tools with::
 
     $ apt-get install python3-pip python3-dev build-essential python3-setuptools
 
-Then install ``pymongo`` library with::
+Then install the ``res-address`` and ``pymongo`` libraries::
 
-    $ pip3 install pymongo
+    $ pip3 install res-address pymongo
 
 Like the *Installation* instructions, you may need administrator/root privileges
 for this step.

--- a/Makefile
+++ b/Makefile
@@ -67,5 +67,5 @@ install-from-pypi:
 
 #build-docker-image:
 	# Remember to update the version in the Dockerfile first !
-#	docker build -t mrsarm/mongotail:3.0b3 .
-#	docker push mrsarm/mongotail:3.0b3
+#	docker build -t mrsarm/mongotail:3.0.0 .
+#	docker push mrsarm/mongotail:3.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,26 @@
-.PHONY: clean install install-dev uninstall check-mongotail-version
+.PHONY: clean install install-dev uninstall check-mongotail-version build upload upload-test
 .DEFAULT_GOAL := install
 
-VENV=venv
+VENV = venv
 
 SYSTEM_PYTHON  = $(or $(shell which python3), $(shell which python))
 SYSTEM_PIP     = $(or $(shell which pip3), $(shell which pip))
 PYTHON	= $(or $(wildcard $(VENV)/bin/python), $(SYSTEM_PYTHON))
-PIP		= $(or $(wildcard $(VENV)/bin/pip), $(SYSTEM_PYTHON))
+PIP		= $(or $(wildcard $(VENV)/bin/pip), $(SYSTEM_PIP))
+
+# PyPI test repo
+TEST_REPO = testpypi
+TEST_INDEX_URL = https://test.pypi.org/simple/
+
+# PyPI main repo
+MAIN_REPO = pypi
+MAIN_INDEX_URL = https://pypi.org/simple/
+
+REPO = ${MAIN_REPO}
+INDEX_URL = ${MAIN_INDEX_URL}
+
+
+PIP_ARGS = --index-url ${MAIN_INDEX_URL}
 
 clean:
 	rm -fR build/
@@ -17,18 +31,36 @@ clean-all: clean
 	rm -Rf ${VENV}
 
 install:
-	${PIP} install .
+	${PIP} install ${PIP_ARGS} .
 
 # Install mongotail in editable mode, linking the module with the local project path
 install-dev: ${VENV}
-	${PIP} install -e .
+	${PIP} install ${PIP_ARGS} -e .
 
 uninstall:
 	yes | ${PIP} uninstall mongotail
 
 ${VENV}:
 	${PYTHON} -m venv ${VENV}
-	${PIP} install -U pip wheel setuptools
+	$(eval PIP := $(shell echo ${VENV}/bin/pip))
+	${PIP} install ${PIP_ARGS} -U pip wheel setuptools
+	${PIP} install ${PIP_ARGS} -U pip build twine
 
 check-mongotail-version:
 	${VENV}/bin/mongotail --version
+
+# Build distributable
+build:
+	${PYTHON} -m build
+
+# Upload the distributable packages on PyPI
+upload: build
+	${PYTHON} -m twine upload --repository ${REPO} dist/*
+
+# Upload the distributable packages on test PyPI
+upload-test: build
+	${PYTHON} -m twine upload --repository ${TEST_REPO} dist/*
+
+# Install the distributable package from PyPI
+install-from-pypi:
+	${PYTHON} -m pip install --index-url ${INDEX_URL} --extra-index-url ${MAIN_INDEX_URL} -U --pre mongotail

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,8 @@ upload-test: build
 # Install the distributable package from PyPI
 install-from-pypi:
 	${PYTHON} -m pip install --index-url ${INDEX_URL} --extra-index-url ${MAIN_INDEX_URL} -U --pre mongotail
+
+#build-docker-image:
+	# Remember to update the version in the Dockerfile first !
+#	docker build -t mrsarm/mongotail:3.0b3 .
+#	docker push mrsarm/mongotail:3.0b3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: clean install install-dev uninstall check-mongotail-version
+.DEFAULT_GOAL := install
+
+VENV=venv
+
+SYSTEM_PYTHON  = $(or $(shell which python3), $(shell which python))
+SYSTEM_PIP     = $(or $(shell which pip3), $(shell which pip))
+PYTHON	= $(or $(wildcard $(VENV)/bin/python), $(SYSTEM_PYTHON))
+PIP		= $(or $(wildcard $(VENV)/bin/pip), $(SYSTEM_PYTHON))
+
+clean:
+	rm -fR build/
+	rm -fR dist/
+	rm -fR .eggs/
+
+clean-all: clean
+	rm -Rf ${VENV}
+
+install:
+	${PIP} install .
+
+# Install mongotail in editable mode, linking the module with the local project path
+install-dev: ${VENV}
+	${PIP} install -e .
+
+uninstall:
+	yes | ${PIP} uninstall mongotail
+
+${VENV}:
+	${PYTHON} -m venv ${VENV}
+	${PIP} install -U pip wheel setuptools
+
+check-mongotail-version:
+	${VENV}/bin/mongotail --version

--- a/README.rst
+++ b/README.rst
@@ -167,11 +167,11 @@ possible with::
 
     $ pip3 install --user mongotail
 
-But the ``mongotail`` executable will be installed in the ``$HOME/.local/bin``
-folder, that in most Linux distributions is not added to the ``$PATH`` variable
-to be able to execute the command without the need to use the full
-path (``$HOME/.local/bin/mongotail``). So either add ``$HOME/.local/bin``
-to the ``$PATH`` variable or execute Mongotail with the full path each time.
+Note that the ``mongotail`` executable will be installed in the ``$HOME/.local/bin``
+folder. If the folder didn't exist before, Pip will create it, but in the
+shell console the path won't be added to the ``$PATH`` variable until Bash is not
+instantiated again, so to be able to execute the command without the need to use
+the full path (``$HOME/.local/bin/mongotail``) just open a new Bash session.
 
 
 Mac OSX Installation

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 Mongotail
 =========
 
+.. image:: docs/images/mongotail-console.png
+
 Mongotail, Log all `MongoDB <http://www.mongodb.org>`_ queries in a *"tail"able* way.
 
 ``mongotail`` is a command line tool to outputs any operation from a Mongo

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,6 @@
 Mongotail
 =========
 
-.. image:: docs/images/mongotail-console.png
-
 Mongotail, Log all `MongoDB <http://www.mongodb.org>`_ queries in a *"tail"able* way.
 
 ``mongotail`` is a command line tool to outputs any operation from a Mongo

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ But the more interesting feature (also like ``tail``) is to see the changes
 in *"real time"* with the ``-f`` option, and occasionally filter the result
 with ``grep`` to find a particular operation.
 
+MongoDB version 2.8 and above are supported.
+
 Syntax
 ------
 
@@ -65,39 +67,34 @@ Optional arguments:
                       consider a query or operation to be slow (use with
                       `--level 1`). Or use with 'status' word to show the
                       current milliseconds configured
--m, --metadata        extra metadata fields to show. Known fields (may vary
-                      depending of the operation and the MongoDB version):
+-m METADATA, --metadata METADATA
+                      extra metadata fields to show. Known fields may vary
+                      depending of the operation and the MongoDB version:
                       millis, nscanned, docsExamined, execStats, lockStats ...
+                      (pass each METADATA field separated by one space)
 -i, --info            get information about the MongoDB server we're connected to
 -v, --verbose         verbose mode (not recommended). All the operations will
                       printed in JSON without format and with all the
                       information available from the log
---ssl                 creates the connection to the server using SSL
---sslCertFile SSL_CERT_FILE
-                      certificate file used to identify the local connection
-                      against MongoDB
---sslKeyFile SSL_KEY_FILE
-                      private keyfile used to identify the local connection
-                      against MongoDB. If included with the certfile then
-                      only the sslCertFile is needed
---sslCertReqs SSL_CERT_REQS
-                      specifies whether a certificate is required from the
-                      other side of the connection, and whether it will be
-                      validated if provided. It must be any of three values:
-                      0 (certificate ignored), 1 (not required, but
-                      validated if provided), 2 (required and validated)
---sslCACerts SSL_CA_CERTS
-                      file that contains a set of concatenated
-                      "certification authority" certificates, which are used
-                      to validate certificates passed from the other end of
-                      the connection
---sslPEMPassword SSL_PEM_PASSPHRASE
-                      password or passphrase for decrypting the private key
-                      in sslCertFile or sslKeyFile. Only necessary if the
-                      private key is encrypted
---sslCrlFile SSL_CRLFILE
-                      path to a PEM or DER formatted certificate revocation
-                      list
+--tls                 creates the connection to the server using
+                      transport layer security
+--tlsCertificateKeyFile TLSCERTIFICATEKEYFILE
+                      client certificate to connect against MongoDB.
+                      It's the concatenation of both the private key and and
+                      the certificate file
+--tlsAllowInvalidCertificates
+                      disable the requirement of a certificate from the
+                      server when TLS is enabled
+--tlsCAFile TLSCAFILE
+                      file that contains a set of concatenated CA certificates,
+                      which are used to validate certificates passed
+                      from the other end of the connection
+--tlsCertificateKeyFilePassword TLSCERTIFICATEKEYFILEPASSWORD
+                      password or passphrase to decrypt the encrypted private
+                      keys if the private key contained in the
+                      certificate keyfile is encrypted.
+--tlsCRLFile TLSCRLFILE
+                      path to a PEM or DER formatted certificate revocation list
 -h, --help            show this help message and exit
 -V, --version         show program's version number and exit
 
@@ -212,7 +209,7 @@ About
 
 Project: https://github.com/mrsarm/mongotail
 
-Authors: (2015-2021) Mariano Ruiz <mrsarm@g...l.com>
+Authors: (2015-2022) Mariano Ruiz <mrsarm@g...l.com>
 
 Changelog: `CHANGELOG.rst <https://github.com/mrsarm/mongotail/blob/master/CHANGELOG.rst>`_
 

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '3.0b1'
+__version__ = '3.0b2'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '3.0.0-rc1'
+__version__ = '3.0b1'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '3.0b3'
+__version__ = '3.0.0'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2021 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2022 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '2.4.1'
+__version__ = '2.5.0-rc1'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '3.0b2'
+__version__ = '3.0b3'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '2.5.0-rc1'
+__version__ = '3.0.0-rc1'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -39,7 +39,7 @@ def connect(address, args):
       it's asked from tty.
     - auth_database: authenticate the username and password against that database (optional).
       If not specified, the database specified in address will be used.
-    - ssl, ssl_certfile, ssl_keyfile, ssl_cert_reqs, ssl_ca_certs: SSL authentication options
+    - tls, tlsCertificateKeyFile, tlsAllowInvalidCertificates, ...: TSL authentication options
     :return: a tuple with ``(client, db)``
     """
     try:
@@ -49,12 +49,18 @@ def connect(address, args):
 
     try:
         options = {}
-        if args.ssl:
-            options["ssl"] = True
-            options["ssl_certfile"] = args.ssl_cert_file
-            options["ssl_keyfile"] = args.ssl_key_file
-            options["ssl_cert_reqs"] = args.ssl_cert_reqs
-            options["ssl_ca_certs"] = args.ssl_ca_certs
+        if args.tls:
+            options["tls"] = True
+            if args.tlsCertificateKeyFile:
+                options["tlsCertificateKeyFile"] = args.tlsCertificateKeyFile
+            if args.tlsCertificateKeyFilePassword:
+                options["tlsCertificateKeyFilePassword"] = args.tlsCertificateKeyFilePassword
+            if args.tlsCAFile:
+                options["tlsCAFile"] = args.tlsCAFile
+            if args.tlsCRLFile:
+                options["tlsCRLFile"] = args.tlsCRLFile
+            if args.tlsAllowInvalidCertificates:
+                options["tlsAllowInvalidCertificates"] = args.tlsAllowInvalidCertificates
 
         client = MongoClient(host=host, port=port, **options)
     except Exception as e:

--- a/mongotail/conn.py
+++ b/mongotail/conn.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2019 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2022 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #

--- a/mongotail/jsondec.py
+++ b/mongotail/jsondec.py
@@ -23,19 +23,12 @@
 
 
 import re, json
-from bson import ObjectId, DBRef, regex
+from bson import ObjectId, DBRef, regex, MinKey, MaxKey
+from bson.decimal128 import Decimal128
 from bson.timestamp import Timestamp
 from datetime import datetime
 from uuid import UUID
 import base64
-try:
-    from bson.decimal128 import Decimal128
-except ImportError:
-    Decimal128 = None
-try:
-    from bson import MinKey, MaxKey
-except ImportError:
-    MinKey = MaxKey = None
 
 REGEX_TYPE = type(re.compile(""))
 
@@ -57,13 +50,12 @@ class JSONEncoder(json.JSONEncoder):
             return "Timestamp(%s, %sTimestamp)" % (o.time, o.inc)
         if isinstance(o, (REGEX_TYPE, regex.Regex)):
             return {"$regex": o.pattern}
-        if Decimal128 and isinstance(o, Decimal128):
+        if isinstance(o, Decimal128):
             return "NumberDecimal(" + str(o) + "NumberDecimal)"
-        if MinKey:
-            if isinstance(o, MinKey):
-                return "MinKey(MinKey)"
-            if isinstance(o, MaxKey):
-                return "MinKey(MinKey)"
+        if isinstance(o, MinKey):
+            return "MinKey(MinKey)"
+        if isinstance(o, MaxKey):
+            return "MinKey(MinKey)"
         if isinstance(o, bytes):
             return 'BinData(0,' + base64.b64encode(o).decode('utf-8') + 'BinData)'
         return json.JSONEncoder.default(self, o)

--- a/mongotail/jsondec.py
+++ b/mongotail/jsondec.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2019 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2022 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #
@@ -24,14 +24,18 @@
 
 import re, json
 from bson import ObjectId, DBRef, regex
-try:
-    from bson.decimal128 import Decimal128
-except ImportError:
-    pass
 from bson.timestamp import Timestamp
 from datetime import datetime
 from uuid import UUID
 import base64
+try:
+    from bson.decimal128 import Decimal128
+except ImportError:
+    Decimal128 = None
+try:
+    from bson import MinKey, MaxKey
+except ImportError:
+    MinKey = MaxKey = None
 
 REGEX_TYPE = type(re.compile(""))
 
@@ -55,6 +59,11 @@ class JSONEncoder(json.JSONEncoder):
             return {"$regex": o.pattern}
         if Decimal128 and isinstance(o, Decimal128):
             return "NumberDecimal(" + str(o) + "NumberDecimal)"
+        if MinKey:
+            if isinstance(o, MinKey):
+                return "MinKey(MinKey)"
+            if isinstance(o, MaxKey):
+                return "MinKey(MinKey)"
         if isinstance(o, bytes):
             return 'BinData(0,' + base64.b64encode(o).decode('utf-8') + 'BinData)'
         return json.JSONEncoder.default(self, o)
@@ -77,6 +86,10 @@ class JSONEncoder(json.JSONEncoder):
         result = result.replace('UUID)"', '")')
         result = result.replace('"NumberDecimal(', 'NumberDecimal("')
         result = result.replace('NumberDecimal)"', '")')
+        result = result.replace('"MinKey(', 'MinKey(')
+        result = result.replace('MinKey)"', ')')
+        result = result.replace('"MaxKey(', 'MaxKey(')
+        result = result.replace('MaxKey)"', ')')
         result = result.replace('"BinData(0,', 'BinData(0,"')
         result = result.replace('BinData)"', '")')
         return result

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -46,6 +46,7 @@ LOG_QUERY = {
         "command.dbstats": {"$exists": False},
         "command.scale": {"$exists": False},
         "command.explain": {"$exists": False},
+        "command.killCursors": {"$exists": False},
         "command.count": {"$ne": "system.profile"},
         "op": re.compile(r"^((?!(getmore|killcursors)).)", re.IGNORECASE),
 }

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -82,15 +82,15 @@ def tail(client, db, lines, follow, verbose, metadata):
 
 def show_profiling_level(client, db):
     try:
-        level = db.profiling_level()
-        sys.stdout.write("Profiling currently set in level %s\n" % level)
+        level = db.command("profile", -1)
+        sys.stdout.write("Profiling currently set in level %s\n" % level["was"])
     except Exception as e:
         error('Error trying to get profiling level. %s' % e, EINTR)
 
 
 def set_profiling_level(client, db, level):
     try:
-        db.set_profiling_level(int(level))
+        db.command("profile", int(level))
         sys.stdout.write("Profiling set to level %s\n" % level)
     except Exception as e:
         err = str(e).replace("OFF", "0").replace("SLOW_ONLY", "1").replace("ALL", "2")
@@ -98,9 +98,9 @@ def set_profiling_level(client, db, level):
 
 
 def set_slowms_level(client, db, slowms):
-    profiling_level = db.profiling_level()
+    profiling_level = db.command("profile", -1)["was"]
     try:
-        db.set_profiling_level(profiling_level, int(slowms))
+        db.command({"profile": profiling_level, "slowms": int(slowms)})
         sys.stdout.write("Threshold profiling set to %s milliseconds\n" % slowms)
     except Exception as e:
         error('Error configuring threshold profiling in "%s" milliseconds. %s' % (slowms, str(e)), EINTR)

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -62,24 +62,13 @@ def tail(client, db, lines, follow, verbose, metadata):
     else:
         fields = LOG_FIELDS
     profile_collection = db.system.profile
-    pymongo_version = get_version_string()
-    if pymongo_version >= "3.0":
-        # Since PyMongo 3.0 fields are passed to `find` function with the parameter `projection`
-        cursor = profile_collection.find(LOG_QUERY, projection=fields)
-    else:
-        # Until PyMongo 2.8 fields are passed to `find` function with the parameter `fields`
-        cursor = profile_collection.find(LOG_QUERY, fields=fields)
+    cursor = profile_collection.find(LOG_QUERY, projection=fields)
     if lines.upper() != "ALL":
         try:
             lines = int(lines)
         except ValueError:
             error_parsing('Invalid lines number "%s"' % lines)
-        if pymongo_version >= "4.0":
-            query_count = profile_collection.count_documents(LOG_QUERY)
-        else:
-            # Cursor#count() was removed on PyMongo 4.0
-            query_count = cursor.count()
-        skip = query_count - lines
+        skip = profile_collection.count_documents(LOG_QUERY) - lines
         if skip > 0:
             cursor.skip(skip)
     if follow:

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -3,7 +3,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2019 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2022 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #
@@ -28,7 +28,6 @@ import sys, re, argparse
 from .conn import connect
 from .out import print_obj
 from .err import error, error_parsing, EINTR, EDESTADDRREQ
-from pymongo import get_version_string
 from pymongo.read_preferences import ReadPreference
 from pymongo.errors import ConnectionFailure
 
@@ -181,27 +180,22 @@ def main():
         parser.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
                             help="verbose mode (not recommended). All the operations will printed in JSON without "
                                  "format and with all the information available from the log")
-        parser.add_argument("--ssl", action="store_true", default=False,
-                            help ="creates the connection to the server using SSL")
-        parser.add_argument("--sslCertFile", dest="ssl_cert_file", default=None,
-                            help ="certificate file used to identify the local connection against MongoDB")
-        parser.add_argument("--sslKeyFile", dest="ssl_key_file", default=None,
-                            help ="private keyfile used to identify the local connection against MongoDB. "
-                                  "If included with the certfile then only the sslCertFile is needed")
-        parser.add_argument("--sslCertReqs", dest="ssl_cert_reqs", default=0,
-                            help="specifies whether a certificate is required from the other side of the connection, "
-                                 "and whether it will be validated if provided. It must be any of three values: "
-                                 "0 (certificate ignored), "
-                                 "1 (not required, but validated if provided), "
-                                 "2 (required and validated)")
-        parser.add_argument("--sslCACerts", dest="ssl_ca_certs", default=None,
-                            help="file that contains a set of concatenated \"certification authority\" "
+        parser.add_argument("--tls", action="store_true", default=False,
+                            help ="creates the connection to the server using transport layer security")
+        parser.add_argument("--tlsCertificateKeyFile", dest="tlsCertificateKeyFile", default=None,
+                            help="client certificate to connect against MongoDB. It's the concatenation of "
+                                 "both the private key and and the certificate file")
+        parser.add_argument("--tlsAllowInvalidCertificates", dest="tlsAllowInvalidCertificates",
+                            action="store_true", default=False,
+                            help="disable the requirement of a certificate from the server when TLS is enabled")
+        parser.add_argument("--tlsCAFile", dest="tlsCAFile", default=None,
+                            help="file that contains a set of concatenated CA "
                                  "certificates, which are used to validate certificates passed from the other "
                                  "end of the connection")
-        parser.add_argument("--sslPEMPassword", dest="ssl_pem_passphrase", default=None,
-                            help="password or passphrase for decrypting the private key in sslCertFile or "
-                                 "sslKeyFile. Only necessary if the private key is encrypted")
-        parser.add_argument("--sslCrlFile", dest="ssl_crlfile", default=None,
+        parser.add_argument("--tlsCertificateKeyFilePassword", dest="tlsCertificateKeyFilePassword", default=None,
+                            help="password for private key contained fn the certificate keyfile is encrypted."
+                                 "")
+        parser.add_argument("--tlsCRLFile", dest="tlsCRLFile", default=None,
                             help="path to a PEM or DER formatted certificate revocation list")
         parser.add_argument("-V", "--version", action="version",
                             version="%(prog)s " + __version__ + " <" + __url__ + "> (python " + sys.version.split(" ")[0] + ")")

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -61,17 +61,25 @@ def tail(client, db, lines, follow, verbose, metadata):
         fields = LOG_FIELDS + metadata
     else:
         fields = LOG_FIELDS
-    if get_version_string() >= "3.0":
+    profile_collection = db.system.profile
+    pymongo_version = get_version_string()
+    if pymongo_version >= "3.0":
         # Since PyMongo 3.0 fields are passed to `find` function with the parameter `projection`
-        cursor = db.system.profile.find(LOG_QUERY, projection=fields)
+        cursor = profile_collection.find(LOG_QUERY, projection=fields)
     else:
         # Until PyMongo 2.8 fields are passed to `find` function with the parameter `fields`
-        cursor = db.system.profile.find(LOG_QUERY, fields=fields)
+        cursor = profile_collection.find(LOG_QUERY, fields=fields)
     if lines.upper() != "ALL":
         try:
-            skip = cursor.count() - int(lines)
+            lines = int(lines)
         except ValueError:
             error_parsing('Invalid lines number "%s"' % lines)
+        if pymongo_version >= "4.0":
+            query_count = profile_collection.count_documents(LOG_QUERY)
+        else:
+            # Cursor#count() was removed on PyMongo 4.0
+            query_count = cursor.count()
+        skip = query_count - lines
         if skip > 0:
             cursor.skip(skip)
     if follow:

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -47,7 +47,7 @@ LOG_QUERY = {
         "command.scale": {"$exists": False},
         "command.explain": {"$exists": False},
         "command.count": {"$ne": "system.profile"},
-        "op": re.compile(r"^((?!(getmore|killcursors)).)"),
+        "op": re.compile(r"^((?!(getmore|killcursors)).)", re.IGNORECASE),
 }
 
 LOG_FIELDS = ['ts', 'op', 'ns', 'query', 'updateobj', 'command', 'ninserted', 'ndeleted', 'nMatched', 'nreturned']

--- a/mongotail/mongotail.py
+++ b/mongotail/mongotail.py
@@ -193,8 +193,8 @@ def main():
                                  "certificates, which are used to validate certificates passed from the other "
                                  "end of the connection")
         parser.add_argument("--tlsCertificateKeyFilePassword", dest="tlsCertificateKeyFilePassword", default=None,
-                            help="password for private key contained fn the certificate keyfile is encrypted."
-                                 "")
+                            help="password or passphrase to decrypt the encrypted private keys if the "
+                                 "private key contained in the certificate keyfile is encrypted")
         parser.add_argument("--tlsCRLFile", dest="tlsCRLFile", default=None,
                             help="path to a PEM or DER formatted certificate revocation list")
         parser.add_argument("-V", "--version", action="version",

--- a/mongotail/out.py
+++ b/mongotail/out.py
@@ -61,7 +61,9 @@ def print_obj(obj, verbose, metadata, mongo_version):
                         query += ', limit: ' + json_encoder.encode_number(cmd['limit'])
                     if 'skip' in cmd:
                         query += ', skip: ' + json_encoder.encode_number(cmd['skip'])
-                query += '. %s returned.' % obj['nreturned']
+                if 'nreturned' in obj:
+                    # If a query fails Mongo doesn't record nreturned
+                    query += '. %s returned.' % obj['nreturned']
             elif operation == 'update':
                 doc = obj['ns'].split(".")[-1]
                 if mongo_version < "3.6":

--- a/setup.py
+++ b/setup.py
@@ -48,22 +48,32 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'pymongo>=3.12',
+        'pymongo>=3.12,<5.0.0',
         'res-address',
     ],
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'mongotail = mongotail.mongotail:main',
         ],
     },
     classifiers=[
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
+        'Topic :: Database',
+        'Topic :: Utilities',
+        'Topic :: Terminals',
         'License :: Public Domain',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Topic :: Database',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'pymongo>=2.8',
+        'pymongo>=3.12',
         'res-address',
     ],
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2019 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2022 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #


### PR DESCRIPTION
* Add support to the new PyMongo driver version 4.0 (#34)
* Add support to the types `MinKey` / `MaxKey` from MongoDB (#35)
* Remove deprecated _~SSL~_ arguments in favor of the new _TLS_ arguments
* Remove support to Python 2.6, 3.3, and 3.4
* Fix when a query fails Mongo doesn't record `nreturned` (number of record returned)
* Fix Mongo logs `killcursors` operations with different cases causing exception when parsing logs