### PR TITLE
Release 3.1.1 and fix CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.7', '3.5', '3.10' ]
+        python-version: [ '2.7', '3.7', '3.10' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ People who have submitted patches and reported bugs:
 * Zach (https://github.com/im-zhangxi)
 * Patrick Portal (https://github.com/pp0rtal)
 * Alex Eimer (https://github.com/aeimer)
+* James Bohnert (https://github.com/jsbohnert)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@ Mongotail changelog
 ===================
 
 
+3.1.1
+-----
+
+* Recognize and support alternate casings of ``findAndModify`` and ``mapReduce``.
+
+
 3.1.0
 -----
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@
 
 FROM python:3.10-slim
 MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
-RUN pip install --no-cache-dir mongotail==3.1.0
+RUN pip install --no-cache-dir mongotail==3.1.1b1
 ENTRYPOINT ["mongotail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@
 
 FROM python:3.10-slim
 MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
-RUN pip install --no-cache-dir mongotail==3.1.1b1
+RUN pip install --no-cache-dir mongotail==3.1.1
 ENTRYPOINT ["mongotail"]

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ upload-test: build
 install-from-pypi:
 	${PYTHON} -m pip install --index-url ${INDEX_URL} --extra-index-url ${MAIN_INDEX_URL} -U --pre mongotail
 
-GREP_VERSION := grep -o -E '[0-9]\.[0-9](b[0-9]|\.[0-9])'
+GREP_VERSION := grep -o -E '[0-9]\.[0-9](\.[0-9])(b[0-9]|\.[0-9])'
 $(eval DOCKER_VERSION := $(shell cat Dockerfile | ${GREP_VERSION} | head -n 1))
 
 check-version:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: clean install install-dev uninstall check-mongotail-version build upload upload-test install-from-pypi check-version docker-build-image docker-push-image docker-tag-image-latest
+.PHONY: clean install install-dev uninstall check-mongotail-version build upload upload-test \
+        install-from-pypi check-version docker-build-image docker-push-image docker-tag-image-latest
 .DEFAULT_GOAL := install
 
 VENV ?= venv
@@ -66,7 +67,7 @@ upload-test: build
 install-from-pypi:
 	${PYTHON} -m pip install --index-url ${INDEX_URL} --extra-index-url ${MAIN_INDEX_URL} -U --pre mongotail
 
-GREP_VERSION := grep -o -E '[0-9]\.[0-9](\.[0-9])(b[0-9]|\.[0-9])'
+GREP_VERSION := grep -o -E '[0-9]\.[0-9](\.[0-9])(b[0-9])?'
 $(eval DOCKER_VERSION := $(shell cat Dockerfile | ${GREP_VERSION} | head -n 1))
 
 check-version:

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '3.1.1b1'
+__version__ = '3.1.1'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/__init__.py
+++ b/mongotail/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2022 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2023 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #
@@ -23,7 +23,7 @@
 
 
 __author__ = 'Mariano Ruiz'
-__version__ = '3.1.0'
+__version__ = '3.1.1b1'
 __license__ = 'GPL-3'
 __url__ = 'https://github.com/mrsarm/mongotail'
 __doc__ = """Mongotail, Log all MongoDB queries in a "tail"able way."""

--- a/mongotail/out.py
+++ b/mongotail/out.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #  Mongotail, Log all MongoDB queries in a "tail"able way.
-#  Copyright (C) 2015-2020 Mariano Ruiz <https://github.com/mrsarm/mongotail>
+#  Copyright (C) 2015-2023 Mariano Ruiz <https://github.com/mrsarm/mongotail>
 #
 #  Author: Mariano Ruiz <mrsarm@gmail.com>
 #


### PR DESCRIPTION
- Release version 3.1.1 with parsing [fix](https://github.com/mrsarm/mongotail/issues/44).
- Fix broken CI with old Python version.