### PR TITLE
Update docker image

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.9', '3.11' ]
+        python-version: [ '3.8', '3.10', '3.12' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [ '3.8', '3.10', '3.12' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade Python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # NOT for development environments
 
-FROM python:3.10-slim
-MAINTAINER Mariano Ruiz <mrsarm@gmail.com>
+FROM python:3.12-slim
+LABEL org.opencontainers.image.authors="Mariano Ruiz <mrsarm@gmail.com>"
 RUN pip install --no-cache-dir mongotail==3.1.1
 ENTRYPOINT ["mongotail"]

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -4,8 +4,8 @@ Installing mongotail
 Prerequisites
 -------------
 
-* Python 3.5+ or 2.7 (only tested with 2.7, 3.5 and 3.7, 3.8 and 3.10)
-* PyMongo 3.12+ (tested with versions 3.12 and 4.0)
+* Python 3.5+ or 2.7 (only tested with 2.7, 3.5, 3.7, 3.8, 3.10 and 3.12)
+* PyMongo 3.12+ (tested with versions 3.12, 4.0, 4.12 and 4.13)
 
 
 Installation

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 ifeq ($(version),x.y.z)
 	$(error "version" cannot be equal to "x.y.z", it was just an example :S)
 endif
-ifneq ($(version),$(DOCKER_VERSION))
+ifneq ($(shell echo $(version) | cut -d'-' -f1),$(DOCKER_VERSION))
 	$(error mongotail version is ${version}, while version defined in the Dockerfile is ${DOCKER_VERSION})
 endif
 


### PR DESCRIPTION
Release a new Docker image version `3.1.1-2` (`latest`), with the same code (mongotail v3.1.1) but with an up-to-date PyMongo driver and Python version.